### PR TITLE
0.19.0

### DIFF
--- a/compiler/common/AST/Source.hs
+++ b/compiler/common/AST/Source.hs
@@ -175,6 +175,7 @@ data Exp_
   | IfTarget SourceTarget
   | ElseIfTarget SourceTarget
   | EndIfTarget
+  | ConstructorAccess Name Name Exp
   | TypedHole
   deriving(Eq, Show, Generic, Hashable)
 

--- a/compiler/common/Canonicalize/Env.hs
+++ b/compiler/common/Canonicalize/Env.hs
@@ -11,6 +11,7 @@ import           Control.Monad.Except
 import qualified Data.Map                      as M
 import           Data.Hashable
 import           GHC.Generics hiding(Constructor)
+import qualified AST.Canonical                 as Can
 
 
 
@@ -18,7 +19,12 @@ data Interface
   = Interface [TVar] [Pred] [String]
   deriving(Eq, Show, Generic, Hashable)
 
+data ConstructorInfo
+  = ConstructorInfo String Int
+  deriving(Eq, Show, Generic, Hashable)
+
 type TypeDecls = M.Map String Type
+type ConstructorInfos = M.Map String [ConstructorInfo]
 type Interfaces = M.Map String Interface
 
 data ImportType
@@ -39,9 +45,10 @@ data ImportInfo
 
 data Env
   = Env
-    { envImportInfo  :: [ImportInfo]
-    , envTypeDecls   :: TypeDecls
-    , envInterfaces  :: Interfaces
+    { envImportInfo :: [ImportInfo]
+    , envTypeDecls :: TypeDecls
+    , envConstructorInfos :: ConstructorInfos
+    , envInterfaces :: Interfaces
     , envCurrentPath :: FilePath
     , envFromDictionaryListName :: String
     , envIsMainModule :: Bool
@@ -53,6 +60,7 @@ data Env
 
 initialEnv :: Env
 initialEnv = Env { envTypeDecls = M.fromList [("List", tList), ("Dictionary", tDictionary), ("Array", tArray), ("ByteArray", tByteArray)]
+                 , envConstructorInfos = M.empty
                  , envInterfaces = M.fromList [("Eq", Interface [TV "a" Star] [] ["=="]), ("Inspect", Interface [TV "a" Star] [] ["inspect"])]
                  , envCurrentPath = ""
                  , envFromDictionaryListName = ""

--- a/compiler/common/Driver/Query.hs
+++ b/compiler/common/Driver/Query.hs
@@ -46,6 +46,7 @@ data Query a where
   CanonicalizedASTWithEnv :: FilePath -> Query (Can.AST, CanEnv.Env, [InstanceToDerive])
   CanonicalizedInterface :: FilePath -> String -> Query (Maybe CanEnv.Interface)
   ForeignADTType :: FilePath -> String -> Query (Maybe Type)
+  ForeignConstructorInfos :: FilePath -> String -> Query (Maybe [CanEnv.ConstructorInfo])
 
   -- Type checking
   SolvedASTWithEnv :: FilePath -> Query (Slv.AST, SlvEnv.Env)
@@ -109,47 +110,50 @@ instance Hashable (Query a) where
     ForeignADTType modulePath typeName ->
       hashWithSalt salt (modulePath <> "." <> typeName, 9 :: Int)
 
+    ForeignConstructorInfos modulePath typeName ->
+      hashWithSalt salt (modulePath <> "." <> typeName, 10 :: Int)
+
     SolvedASTWithEnv path ->
-      hashWithSalt salt (path, 10 :: Int)
+      hashWithSalt salt (path, 11 :: Int)
 
     SolvedInterface path name ->
-      hashWithSalt salt (path, name, 11 :: Int)
+      hashWithSalt salt (path, name, 12 :: Int)
 
     ForeignScheme modulePath typeName ->
-      hashWithSalt salt (modulePath <> "." <> typeName, 12 :: Int)
+      hashWithSalt salt (modulePath <> "." <> typeName, 13 :: Int)
 
     ForeignExp modulePath expName ->
-      hashWithSalt salt (modulePath <> "." <> expName, 13 :: Int)
+      hashWithSalt salt (modulePath <> "." <> expName, 14 :: Int)
 
     ForeignConstructor modulePath constructorName ->
-      hashWithSalt salt (modulePath <> "." <> constructorName, 14 :: Int)
+      hashWithSalt salt (modulePath <> "." <> constructorName, 15 :: Int)
 
     ForeignTypeDeclaration modulePath typeName ->
-      hashWithSalt salt (modulePath <> "." <> typeName, 15 :: Int)
+      hashWithSalt salt (modulePath <> "." <> typeName, 16 :: Int)
 
     CoreAST path ->
-      hashWithSalt salt (path, 16 :: Int)
-
-    BuiltObjectFile path ->
       hashWithSalt salt (path, 17 :: Int)
 
+    BuiltObjectFile path ->
+      hashWithSalt salt (path, 18 :: Int)
+
     BuiltInBuiltObjectFile ->
-      hashWithSalt salt (18 :: Int)
+      hashWithSalt salt (19 :: Int)
 
     GeneratedJSModule path ->
-      hashWithSalt salt (path, 19 :: Int)
-
-    BuiltJSModule path ->
       hashWithSalt salt (path, 20 :: Int)
 
-    BuiltTarget path ->
+    BuiltJSModule path ->
       hashWithSalt salt (path, 21 :: Int)
 
-    StaticLibPathsToLink path ->
+    BuiltTarget path ->
       hashWithSalt salt (path, 22 :: Int)
 
+    StaticLibPathsToLink path ->
+      hashWithSalt salt (path, 23 :: Int)
+
     EnvVar name ->
-      hashWithSalt salt (name, 23 :: Int)
+      hashWithSalt salt (name, 24 :: Int)
 
 
 instance Hashable (Some Query) where

--- a/compiler/common/Error/Error.hs
+++ b/compiler/common/Error/Error.hs
@@ -52,6 +52,9 @@ data TypeError
   | OverloadedMutation String [Pred]
   | NoMain
   | NotADefinition
+  | ConstructorAccessBadIndex String String Int Int
+  | ConstructorAccessNoConstructorFound String
+  | ConstructorAccessTooManyConstructors String Int
   deriving (Show, Eq, Ord)
 
 

--- a/compiler/main/Canonicalize/ADT.hs
+++ b/compiler/main/Canonicalize/ADT.hs
@@ -55,11 +55,12 @@ canonicalizeTypeDecl env astPath td@(Src.Source area _ typeDecl) = case typeDecl
       Nothing -> do
         verifyTypeVars area astPath (Src.adtname adt) (Src.adtparams adt)
 
-        let t    = TCon (TC (Src.adtname adt) (buildKind (length $ Src.adtparams adt))) astPath
-            vars = (\n -> TVar (TV n Star)) <$> Src.adtparams adt
-            t'   = foldl1 TApp (t : vars)
-            env' = addADT env (Src.adtname adt) t'
-        canonicalizeConstructors env' astPath td
+        let t     = TCon (TC (Src.adtname adt) (buildKind (length $ Src.adtparams adt))) astPath
+            vars  = (\n -> TVar (TV n Star)) <$> Src.adtparams adt
+            t'    = foldl1 TApp (t : vars)
+            env'  = addADT env (Src.adtname adt) t'
+            env'' = addConstructorInfos env' (Src.adtname adt) (map (\(Src.Source _ _ (Src.Constructor name params)) -> ConstructorInfo name (length params)) (Src.adtconstructors adt))
+        canonicalizeConstructors env'' astPath td
 
   alias@Src.Alias{} -> do
     verifyTypeVars area astPath (Src.aliasname alias) (Src.aliasparams alias)

--- a/compiler/main/Canonicalize/EnvUtils.hs
+++ b/compiler/main/Canonicalize/EnvUtils.hs
@@ -3,17 +3,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Canonicalize.EnvUtils where
 
-import qualified Data.Map as Map
+import qualified Data.Map               as Map
 import           Canonicalize.Env
 import           Canonicalize.CanonicalM
 import qualified Rock
-import qualified Driver.Query as Query
-import qualified Data.List    as List
-import Infer.Type
-import Control.Monad.Except
-import Error.Error
-import Error.Context
-import Text.Show.Pretty
+import qualified Driver.Query           as Query
+import qualified Data.List              as List
+import           Infer.Type
+import           Control.Monad.Except
+import           Error.Error
+import           Error.Context
 
 
 addADT :: Env -> String -> Type -> Env
@@ -23,11 +22,41 @@ addADT env name adt =
   in  env { envTypeDecls = withAddition }
 
 
+addConstructorInfos :: Env -> String -> [ConstructorInfo] -> Env
+addConstructorInfos env typeName infos =
+  let constructorInfos = envConstructorInfos env
+      withInfos = Map.insert typeName infos constructorInfos
+  in  env { envConstructorInfos = withInfos }
+
+
 isTypeNameInImport :: String -> ImportInfo -> Bool
 isTypeNameInImport typeName ImportInfo { iiType, iiName }
   | iiType == TypeImport && iiName == typeName = True
   | iiType == NamespaceImport && iiName == takeWhile (/= '.') typeName = True
   | otherwise = False
+
+
+lookupConstructorInfos :: Env -> String -> CanonicalM (Maybe [ConstructorInfo])
+lookupConstructorInfos env name = do
+  case List.find (isTypeNameInImport name) $ envImportInfo env of
+    Just (ImportInfo path TypeImport typeName) ->
+      Rock.fetch $ Query.ForeignConstructorInfos path typeName
+
+    Just (ImportInfo path NamespaceImport _) ->
+      if '.' `elem` name then
+        Rock.fetch $ Query.ForeignConstructorInfos path (tail $ dropWhile (/= '.') name)
+      else
+        Rock.fetch $ Query.ForeignConstructorInfos path name
+
+    _ ->
+      return $ Map.lookup name (envConstructorInfos env)
+
+  -- case maybeType of
+  --   Just t ->
+  --     return t
+
+  --   Nothing ->
+  --     throwError $ CompilationError (UnknownType name) NoContext
 
 
 lookupADT :: Env -> String -> CanonicalM Type

--- a/compiler/main/Infer/AST.hs
+++ b/compiler/main/Infer/AST.hs
@@ -435,8 +435,11 @@ verifyTopLevelExp astPath exp = case exp of
   Slv.Typed _ _ (Slv.TypeExport _) ->
     return ()
 
-  _ ->
+  _ | not $ ".spec.mad" `isSuffixOf` astPath ->
     throwError $ CompilationError NotADefinition (Context astPath (Slv.getArea exp))
+
+  _ ->
+    return ()
 
 
 deriveExtra :: Options -> Env -> [InstanceToDerive] -> Set.Set InstanceToDerive -> Infer (Env, [Slv.Instance])

--- a/compiler/main/Parse/Madlib/Grammar.y
+++ b/compiler/main/Parse/Madlib/Grammar.y
@@ -347,7 +347,10 @@ exp :: { Src.Exp }
   | app                                                      %shift { $1 }
   | absOrParenthesizedName                                   %shift { $1 }
   | '(' exp ')'                                              %shift { Src.Source (mergeAreas (tokenArea $1) (tokenArea $3)) (tokenTarget $1) (Src.Parenthesized (tokenArea $1) $2 (tokenArea $3)) }
-  | exp '.' name                                             %shift { access $1 (Src.Source (tokenArea $3) (Src.getSourceTarget $1) (Src.Var $ "." <> strV $3)) }
+  | exp '.' name                                                    { access $1 (Src.Source (tokenArea $3) (Src.getSourceTarget $1) (Src.Var $ "." <> strV $3)) }
+  | name '.' name                                                   { access (Src.Source (tokenArea $1) (tokenTarget $1) (Src.Var $ strV $1)) (Src.Source (tokenArea $3) (tokenTarget $1) (Src.Var $ "." <> strV $3)) }
+  | constructorAccess                                               { $1 }
+  -- | name '.' number '(' exp ')'                               { Src.Source (mergeAreas (tokenArea $1) (tokenArea $6)) (tokenTarget $1) (Src.ConstructorAccess (strV $1) (strV $3) $5) }
   | 'if' '(' exp ')' '{' maybeRet exp maybeRet '}' maybeRet 'else' maybeRet '{' maybeRet exp maybeRet '}'
       { Src.Source (mergeAreas (tokenArea $1) (tokenArea $17)) (tokenTarget $1) (Src.If $3 $7 $15) }
   | 'if' '(' exp ')' '{' maybeRet exp maybeRet '}' maybeRet
@@ -366,6 +369,11 @@ exp :: { Src.Exp }
       { Src.Source (mergeAreas (Src.getArea $1) (Src.getArea $8)) (Src.getSourceTarget $1) (Src.Ternary $1 $4 $8) }
   | exp '?' maybeRet exp maybeRet ':' maybeRet exp 'ret'
       { Src.Source (mergeAreas (Src.getArea $1) (Src.getArea $8)) (Src.getSourceTarget $1) (Src.Ternary $1 $4 $8) }
+
+
+constructorAccess :: { Src.Exp }
+  : name '[' number ']' '(' exp ')'          { Src.Source (mergeAreas (tokenArea $1) (tokenArea $7)) (tokenTarget $1) (Src.ConstructorAccess (strV $1) (strV $3) $6) }
+  | name '.' name '[' number ']' '(' exp ')' { Src.Source (mergeAreas (tokenArea $1) (tokenArea $9)) (tokenTarget $1) (Src.ConstructorAccess (strV $1 <> "." <> strV $3) (strV $5) $8) }
 
 
 absOrParenthesizedName :: { Src.Exp }

--- a/compiler/main/Run/Format.hs
+++ b/compiler/main/Run/Format.hs
@@ -128,7 +128,11 @@ runFormatter width fix path code = do
   astsWithComments <-
     if code == "--EMPTY--" then do
       filesToFormat <- getFilesToCompile False path
-      parseASTsToFormat filesToFormat
+      if null filesToFormat then do
+        putStrLn $ "No file to format found, verify that the directory or file '" <> path <> "' exists!"
+        exitFailure
+      else
+        parseASTsToFormat filesToFormat
     else
       parseCodeToFormat code
 

--- a/compiler/main/Run/TestRunner.hs
+++ b/compiler/main/Run/TestRunner.hs
@@ -211,8 +211,12 @@ generateTestSuiteImport (index, path) =
 generateTestSuiteItemExp :: Int -> FilePath -> ListItem
 generateTestSuiteItemExp index testSuitePath =
   let testsAccess = Source emptyArea TargetAll (Access (Source emptyArea TargetAll (Var $ generateTestSuiteName index)) (Source emptyArea TargetAll (Var ".__tests__")))
+      beforeAll = Source emptyArea TargetAll (Access (Source emptyArea TargetAll (Var $ generateTestSuiteName index)) (Source emptyArea TargetAll (Var ".beforeAll")))
+      afterAll = Source emptyArea TargetAll (Access (Source emptyArea TargetAll (Var $ generateTestSuiteName index)) (Source emptyArea TargetAll (Var ".afterAll")))
   in  Source emptyArea TargetAll (ListItem (Source emptyArea TargetAll (TupleConstructor [
         Source emptyArea TargetAll (LStr $ "\"" <> testSuitePath <> "\""),
+        beforeAll,
+        afterAll,
         testsAccess
       ])))
 

--- a/compiler/main/Run/Utils.hs
+++ b/compiler/main/Run/Utils.hs
@@ -72,14 +72,18 @@ getFilesToCompile testsOnly entrypoint = case takeExtension entrypoint of
     return []
 
   _          -> do
-    paths <- getDirectoryContents entrypoint
-    let fullPaths =
-          (\file -> joinPath [entrypoint, file])
-            <$> filter (\p -> p /= "." && p /= ".." && not (any (`isSuffixOf` p) compilationBlackList)) paths
-    let filtered = if not testsOnly
-          then filter ((== ".mad") . takeExtension) fullPaths
-          else filter (isSuffixOf ".spec.mad") fullPaths
+    isThere <- doesDirectoryExist entrypoint
+    if isThere then do
+      paths <- getDirectoryContents entrypoint
+      let fullPaths =
+            (\file -> joinPath [entrypoint, file])
+              <$> filter (\p -> p /= "." && p /= ".." && not (any (`isSuffixOf` p) compilationBlackList)) paths
+      let filtered = if not testsOnly
+            then filter ((== ".mad") . takeExtension) fullPaths
+            else filter (isSuffixOf ".spec.mad") fullPaths
 
-    subFolders <- filterM doesDirectoryExist fullPaths
-    next       <- mapM (getFilesToCompile testsOnly) subFolders
-    return $ filtered ++ concat next
+      subFolders <- filterM doesDirectoryExist fullPaths
+      next       <- mapM (getFilesToCompile testsOnly) subFolders
+      return $ filtered ++ concat next
+    else
+      return []

--- a/prelude/__internal__/JsonParser.mad
+++ b/prelude/__internal__/JsonParser.mad
@@ -172,7 +172,7 @@ getParserFn = (parser) => where(parser) {
  * parse(string, `"Json string"`) // Right("Json string")
  * parse(string, `3`) // Left("Error parsing string")
  */
-parse :: Parser b -> String -> Either String b
+parse :: Parser a -> String -> Either String a
 export parse = (parser, input) => pipe(
   runParser(jsonValue),
   where {
@@ -186,6 +186,13 @@ export parse = (parser, input) => pipe(
       }
   }
 )(input)
+
+
+parseJsonValue :: Parser a -> JsonValue -> Either String a
+export parseJsonValue = (parser, input) => where(parser) {
+  Parser(parserFn) =>
+    parserFn(input)
+}
 
 
 /**

--- a/prelude/__internal__/JsonParser.spec.mad
+++ b/prelude/__internal__/JsonParser.spec.mad
@@ -1,7 +1,7 @@
 import { assertEquals, test } from "Test"
 
 import { Left, Right } from "./Either"
-import { list, parse, string } from "./JsonParser"
+import { list, parse, string, float } from "./JsonParser"
 
 
 
@@ -17,3 +17,8 @@ test(
 )
 
 test("list  - error", () => assertEquals(parse(list(string), `1`), Left("Error parsing list")))
+
+test("float - good", () => assertEquals(parse(float, `1.3`), Right(1.3)))
+
+// TODO: revisit that behavior and don't make the '.' mandatory
+test("float - fail for integers", () => assertEquals(parse(float, `1`), Left("Error parsing float")))

--- a/prelude/__internal__/Number.mad
+++ b/prelude/__internal__/Number.mad
@@ -34,19 +34,19 @@ instance Show Float {
 
 import { Just, Nothing } from "Maybe"
 
-scanInteger :: Number a => String -> Maybe a
+scanInteger :: String -> Maybe Integer
 scanInteger = (str) => (#- {
   const n = parseInt(str)
   return isNaN(n) ? Nothing : Just(n)
 } -#)
 
-scanFloat :: Number a => String -> Maybe a
+scanFloat :: String -> Maybe Float
 scanFloat = (str) => (#- {
   const n = parseFloat(str)
   return isNaN(n) ? Nothing : Just(n)
 } -#)
 
-scanByte :: Number a => String -> Maybe a
+scanByte :: String -> Maybe Byte
 scanByte = (str) => (#- {
   const n = parseInt(str)
   return isNaN(n) ? Nothing : Just(n)

--- a/prelude/__internal__/Test.mad
+++ b/prelude/__internal__/Test.mad
@@ -298,8 +298,8 @@ updateSuiteResult = (suitePath, result, a) => {
 }
 
 
-runTestSuite :: String -> List (Wish.Wish String String) -> Wish.Wish {} TestReport
-runTestSuite = (suitePath, testsInSuite) => pipe(
+runTestSuite :: (Inspect e, Inspect f) => String -> ({} -> Wish e a) -> ({} -> Wish f b) -> List (Wish.Wish String String) -> Wish.Wish {} TestReport
+runTestSuite = (suitePath, beforeAll, afterAll, testsInSuite) => pipe(
   (tests) => {
     pipe(
       Dictionary.insert(suitePath, SuiteResult(List.length(tests), 0, 0)),
@@ -310,6 +310,12 @@ runTestSuite = (suitePath, testsInSuite) => pipe(
   },
   map(Wish.bichain(pipe(updateSuiteResult(suitePath, Failure), failureReport, of), pipe(updateSuiteResult(suitePath, Success), successReport, of))),
   Wish.parallel,
+  (testsWish) => Wish.bichain(pipe(IO.log, () => Wish.bad({})), () => testsWish, beforeAll()),
+  (testsWish) => do {
+    result <- testsWish
+    _ <- Wish.bichain(pipe(IO.log, () => Wish.bad({})), () => of({}), afterAll())
+    return of(result)
+  },
   map(
     pipe(
       List.reduce(mergeReports, EMPTY_REPORT),
@@ -329,9 +335,11 @@ runTestSuite = (suitePath, testsInSuite) => pipe(
 )(testsInSuite)
 
 
-runAllTestSuites :: List #[String, List (Wish.Wish String String)] -> {}
+runAllTestSuites :: (Inspect e, Inspect f) => List #[String, ({} -> Wish e a), ({} -> Wish f b), List (Wish.Wish String String)] -> {}
 export runAllTestSuites = (testSuites) => pipe(
-  map((testSuite) => runTestSuite(Tuple.fst(testSuite), Tuple.snd(testSuite))),
+  map(where {
+    #[path, beforeAll, afterAll, tests] =>
+      runTestSuite(path, beforeAll, afterAll, tests)}),
   (suites) => {
     if (IS_COLOR_ENABLED) {
       printSuiteResults(collector.getResults())


### PR DESCRIPTION
**Todo**
- [ ] fixes to madlib format
- [ ] constructor access ( `Type[index](value)` ) described in #97 
- [x] beforeAll and afterAll hooks for test suites