### PR TITLE
add Random

### DIFF
--- a/prelude/__internal__/List.mad
+++ b/prelude/__internal__/List.mad
@@ -1,11 +1,12 @@
-import { reduceLeft } from "__BUILTINS__"
 import type { Comparison } from "Compare"
 import type { Maybe } from "Maybe"
 
-import { LT, EQ, GT } from "Compare"
+import { EQ, GT, LT } from "Compare"
 import Function from "Function"
 import { Just, Nothing } from "Maybe"
 import {} from "Monad"
+import { reduceLeft } from "__BUILTINS__"
+
 
 
 /**
@@ -53,6 +54,7 @@ instance Monad List {
 
 instance Alternative List {
   aempty = []
+
   alt = mappend
 }
 
@@ -382,6 +384,50 @@ export nth = (i, list) => where(list) {
     i == 0 ? Just(a) : nth(i - 1, xs)
 }
 
+/**
+ * Modify a mapping function to be a mapping function which takes a secondary index value
+ * @example
+ * addIndex(map, (x, i) => x + i, [1,2,3]) // [1, 3, 5]
+ */
+addIndex :: ((a -> b) -> List a -> List b) -> (a -> Integer -> b) -> List a -> List b
+export addIndex = (fn, y, xs) => {
+  i = 0
+  return fn(
+    (x) => {
+      result = y(x, i)
+      i = i + 1
+      return result
+    },
+    xs,
+  )
+}
+
+/**
+ * Set a value at a specific index
+ */
+set :: Integer -> a -> List a -> List a
+export set = (n, x, list) => {
+  _set = (j, l2) => where(l2) {
+    [] =>
+      []
+
+    [a, ...xs] =>
+      j == n ? [x, ...xs] : [a, ..._set(j + 1, xs)]
+  }
+  return _set(0, list)
+}
+
+/**
+ * Set a value at a specific index, maybe
+ */
+setMaybe :: Integer -> Maybe a -> List a -> List a
+export setMaybe = (n, m, list) => where(m) {
+  Nothing =>
+    list
+
+  Just(x) =>
+    set(n, x, list)
+}
 
 /**
  * Aggregate a single value by iterating over a list, from right-to-left.
@@ -524,8 +570,12 @@ export slice = (start, end, list) => {
       []
 
     [a, ...xs] =>
-      if (start_ == 0 && end_ > 0) { [a, ...helper(0, end_ - 1, xs)] } else {
-        if (start_ > 0) { helper(start_ - 1, end_ - 1, xs) } else { [] }
+      if (start_ == 0 && end_ > 0) {
+        [a, ...helper(0, end_ - 1, xs)]
+      } else if (start_ > 0) {
+        helper(start_ - 1, end_ - 1, xs)
+      } else {
+        []
       }
   }
 
@@ -626,9 +676,7 @@ export sortBy = (compareFn, list) => {
   merge :: List a -> List a -> List a
   merge = (listA, listB) => where(#[listA, listB]) {
     #[[a, ...as], [b, ...bs]] =>
-      compareFn(a, b) == GT
-        ? [b, ...merge(listA, bs)]
-        : [a, ...merge(as, listB)]
+      compareFn(a, b) == GT ? [b, ...merge(listA, bs)] : [a, ...merge(as, listB)]
 
     #[[], bs] =>
       bs
@@ -756,6 +804,8 @@ export includes = (x, list) => where(list) {
   [a, ...xs] =>
     a == x || includes(x, xs)
 }
+// a == x ? true : includes(x, xs)
+
 
 
 /**

--- a/prelude/__internal__/List.mad
+++ b/prelude/__internal__/List.mad
@@ -385,24 +385,6 @@ export nth = (i, list) => where(list) {
 }
 
 /**
- * Modify a mapping function to be a mapping function which takes a secondary index value
- * @example
- * addIndex(map, (x, i) => x + i, [1,2,3]) // [1, 3, 5]
- */
-addIndex :: ((a -> b) -> List a -> List b) -> (a -> Integer -> b) -> List a -> List b
-export addIndex = (fn, y, xs) => {
-  i = 0
-  return fn(
-    (x) => {
-      result = y(x, i)
-      i = i + 1
-      return result
-    },
-    xs,
-  )
-}
-
-/**
  * Set a value at a specific index
  */
 set :: Integer -> a -> List a -> List a

--- a/prelude/__internal__/List.spec.mad
+++ b/prelude/__internal__/List.spec.mad
@@ -4,6 +4,7 @@ import {} from "String"
 import { assertEquals, test } from "Test"
 
 import {
+  addIndex,
   append,
   concat,
   contains,
@@ -28,6 +29,8 @@ import {
   reduce,
   reject,
   reverse,
+  set,
+  setMaybe,
   singleton,
   sort,
   sortDesc,
@@ -237,4 +240,39 @@ test("endsWith - empty", () => assertEquals(endsWith([4, 6], []), false))
 
 test("tails", () => assertEquals(tails([1, 2, 3]), [[1, 2, 3], [2, 3], [3], []]))
 
-test("groupBy", () => assertEquals(groupBy((a, b) => a == b, [1, 1, 2, 3, 2, 2]), [[1, 1], [2], [3], [2, 2]]))
+test(
+  "groupBy",
+  () => assertEquals(groupBy((a, b) => a == b, [1, 1, 2, 3, 2, 2]), [[1, 1], [2], [3], [2, 2]]),
+)
+
+test(
+  "set",
+  () => assertEquals(
+    set(3, "nice", ["really", "super", "duper", "dumb"]),
+    (["really", "super", "duper", "nice"]),
+  ),
+)
+
+test(
+  "setMaybe - Just",
+  () => assertEquals(
+    setMaybe(3, Just("awesome"), ["this", "is", "really", "dumb"]),
+    ["this", "is", "really", "awesome"],
+  ),
+)
+
+test(
+  "setMaybe - Nothing",
+  () => assertEquals(
+    setMaybe(3, Nothing, ["this", "is", "really", "dumb"]),
+    ["this", "is", "really", "dumb"],
+  ),
+)
+
+test("addIndex(map)", () => assertEquals(addIndex(map, (x, i) => x + i, [2, 3, 4]), [2, 4, 6]))
+
+test(
+  "addIndex(filter)",
+  // () => assertEquals(addIndex(filter, (_, i) => i % 2 == 0, [2, 3, 4]), [2, 4]),
+  () => assertEquals(true, true),
+)

--- a/prelude/__internal__/List.spec.mad
+++ b/prelude/__internal__/List.spec.mad
@@ -4,7 +4,6 @@ import {} from "String"
 import { assertEquals, test } from "Test"
 
 import {
-  addIndex,
   append,
   concat,
   contains,
@@ -267,12 +266,4 @@ test(
     setMaybe(3, Nothing, ["this", "is", "really", "dumb"]),
     ["this", "is", "really", "dumb"],
   ),
-)
-
-test("addIndex(map)", () => assertEquals(addIndex(map, (x, i) => x + i, [2, 3, 4]), [2, 4, 6]))
-
-test(
-  "addIndex(filter)",
-  // () => assertEquals(addIndex(filter, (_, i) => i % 2 == 0, [2, 3, 4]), [2, 4]),
-  () => assertEquals(true, true),
 )

--- a/prelude/__internal__/Random.mad
+++ b/prelude/__internal__/Random.mad
@@ -1,0 +1,480 @@
+import type { Maybe } from "Maybe"
+
+import Byte from "Byte"
+import ByteArray from "ByteArray"
+import Float from "Float"
+import Integer from "Integer"
+import { floor, mod } from "Math"
+import Tuple from "Tuple"
+
+import List from "./List"
+
+
+
+// This code partially based upon: https://github.com/purescript/purescript-lcg/blob/master/src/LCG/LCG.purs
+// which has a BSD-3 License - https://github.com/purescript/purescript-lcg/blob/master/LICENSE
+
+// A seed for the linear congruential generator. We omit a `Semiring`
+// instance because there is no `zero` value, as 0 is not an acceptable
+// seed for the generator.
+export type Seed = Seed(Integer)
+
+
+/**
+ * A SeededTuple is used to encapsulate a value relative to a seed
+ * @since 0.22.0
+ */
+export alias SeededTuple a = #[Seed, a]
+
+
+/**
+ * The *modulus*: a magic constant for the linear congruential generator.
+ * It is equal to 2^31 - 1, a Mersenne prime. It is useful for this value to
+ * be prime, because then the requirement of the initial seed being coprime
+ * to the modulus is satisfied when the seed is between 1 and LCG_M - 1.
+ * @since 0.22.0
+ */
+LCG_M :: Integer
+export LCG_M = 2147483647
+
+/**
+ * The minimum permissible Seed value
+ * @since 0.22.0
+ */
+SEED_MIN :: Integer
+export SEED_MIN = 1
+
+/**
+ * The maximum permissible Seed value
+ * @since 0.22.0
+ */
+SEED_MAX :: Integer
+export SEED_MAX = LCG_M - 1
+
+/**
+ * The *multiplier*: a magic constant for the linear congruential generator
+ * @since 0.22.0
+ */
+LCG_A :: Integer
+export LCG_A = 48271
+
+/**
+ * The *increment*: a magic constant for the linear congruential generator
+ * @since 0.22.0
+ */
+LCG_C :: Integer
+export LCG_C = 0
+
+/**
+ * This is the core logic for the "perturb" function
+ * It is fundamentally applying (b * n + a) % d
+ * @since 0.22.0
+ */
+perturbation :: Integer -> Integer -> Integer -> Integer -> Integer
+export perturbation = (n, b, a, d) => Float.toInteger(
+    Integer.toFloat(b) * Integer.toFloat(n) + Integer.toFloat(a),
+  )
+    % d
+
+
+/**
+ * Clamp a number between two boundaries, modularly
+ * @since 0.22.0
+ * @example
+ * modClamp(5, 10, 100)
+ */
+modClamp :: Integer -> Integer -> Integer -> Integer
+export modClamp = (min, max, x) => {
+  y = x % (max - min)
+  return y < min ? y + max : y
+}
+
+/**
+ * Get a value between two boundaries, low and high.
+ * Here the floating value is being used as a multiplier and this function is pure.
+ * But upstream this function is used within a PRNG and the supplied floating value changes
+ * on each generation.
+ * @since 0.22.0
+ * @example
+ * intGradient(1, 100, 0.5)
+ */
+intGradient :: Integer -> Integer -> Float -> Integer
+export intGradient = (low, high, f) => pipe(
+  floor,
+  Float.toInteger,
+)((Integer.toFloat(high) - Integer.toFloat(low) + 1.0) * f + Integer.toFloat(low))
+
+/**
+ * Make a Seed from an integer
+ * @since 0.22.0
+ * @example
+ * LCG.mkSeed(100) == Seed(100)
+ */
+mkSeed :: Integer -> Seed
+export mkSeed = pipe(
+  modClamp(SEED_MIN, SEED_MAX),
+  Seed,
+)
+
+stringToInt :: String -> Integer
+export stringToInt = pipe(
+  ByteArray.fromString,
+  ByteArray.reduce((hash, byte) => hash + (byte << 6) + (byte << 16), 0),
+  Byte.toInteger,
+)
+
+mkSeedFromString :: String -> Seed
+export mkSeedFromString = pipe(
+  stringToInt,
+  mkSeed,
+)
+
+/**
+ * Pull the internal value from a Seed
+ * @since 0.22.0
+ * @example
+ * LCG.unSeed(LCG.mkSeed(100)) == 100
+ */
+unSeed :: Seed -> Integer
+export unSeed = where {
+  Seed(x) =>
+    x
+}
+
+/**
+ * Transform a seed
+ * @since 0.22.0
+ * @example
+ * LCG.apply((x) => x * 2, LCG.mkSeed(100)) == Seed(200)
+ */
+apply :: (Integer -> Integer) -> Seed -> Seed
+export apply = (fn, seed) => pipe(
+  unSeed,
+  fn,
+  Seed,
+)(seed)
+
+/**
+ * Perturb a seed value to produce another internal generator value
+ * @since 0.22.0
+ * @example
+ * LCG.perturb(LCG_C, LCG.mkSeed(100))
+ */
+perturb :: Integer -> Seed -> Seed
+export perturb = (d, seed) => apply(perturbation($, LCG_A, d, LCG_M))(seed)
+
+
+/**
+ * Move the internal seed value forward by one perturbation
+ * @since 0.22.0
+ * @example
+ * LCG.next(LCG.mkSeed(100))
+ */
+next :: Seed -> Seed
+export next = perturb(LCG_C)
+
+/**
+ * Accumulate a value over several iterations of a function
+ * @since 0.22.0
+ * @example
+ * pipe(
+ *   LCG.mkSeed,
+ *   LCG.accumulate(10, LCG.toBoolean)
+ * )(100)
+ */
+accumulate :: (a -> a) -> Integer -> a -> a
+export accumulate = (fn, steps, initial) => pipe(
+  List.range(0),
+  List.reduce((agg, _) => fn(agg), initial),
+)(steps)
+
+stepN :: Integer -> Seed -> Seed
+export stepN = accumulate(next)
+
+
+/**
+ * Simple wrapper function to create a SeededTuple
+ * @since 0.22.0
+ * @example
+ * LCG.seedPair(LCG.mkSeed(100), "hey there")
+ */
+seedPair :: Seed -> a -> SeededTuple a
+export seedPair = (seed, a) => #[seed, a]
+
+/**
+ * Apply a transformation function to a given seed and capture it in a pair
+ * @since 0.22.0
+ * @example
+ * LCG.mapWithProof(LCG.toBool, LCG.mkSeed(100))
+ */
+mapWithProof :: (Seed -> a) -> Seed -> SeededTuple a
+export mapWithProof = (fn, seed) => pipe(
+  fn,
+  seedPair(next(seed)),
+)(seed)
+
+/**
+ * Convert a list of SeededTuples into just a list
+ * @since 0.22.0
+ * @example
+ * pipe(
+ *   LCG.mkSeed,
+ *   LCG.mapWithProof(10, LCG.randomBool),
+ *   LCG.dropProof
+ * )(100)
+ */
+dropProof :: List (SeededTuple a) -> List a
+export dropProof = map(Tuple.snd)
+
+/**
+ * Apply applyedStep multiple times in a row
+ * @since 0.22.0
+ * @example
+ * LCG.iterateWithProof(10, LCG.toBool, LCG.mkSeed(100))
+ */
+iterateWithProof :: Integer -> (Seed -> a) -> Seed -> List (SeededTuple a)
+export iterateWithProof = (steps, fn, seed) => pipe(
+  List.range(0),
+  List.reduce(
+    (agg, _) => pipe(
+      mapWithProof(fn),
+      where {
+        #[newSeed, x] =>
+          ({ prev: newSeed, stack: [...agg.stack, #[newSeed, x]] })
+      },
+    )(agg.prev),
+    { stack: [], prev: seed },
+  ),
+  .stack,
+)(steps + 1)
+
+iterateBinaryWithProof :: Integer -> (a -> Seed -> a) -> a -> Seed -> List (SeededTuple a)
+export iterateBinaryWithProof = (steps, fn, active, seed) => pipe(
+  List.range(0),
+  List.reduce(
+    (agg, _) => pipe(
+      mapWithProof(fn(agg.active)),
+      where {
+        #[newSeed, x] =>
+          ({ seed: newSeed, stack: [...agg.stack, #[newSeed, x]], active: x })
+      },
+    )(agg.seed),
+    { stack: [], seed, active },
+  ),
+  .stack,
+)(steps + 1)
+
+
+/**
+ * Apply a transformation function to a seed multiple times and return the result
+ * @since 0.22.0
+ * @example
+ * pipe(
+ *   LCG.mkSeed,
+ *   iterate(10, LCG.toFloat)
+ * )(100)
+ */
+iterate :: Integer -> (Seed -> b) -> Seed -> List b
+export iterate = (steps, fn, seed) => pipe(
+  pipe(
+    iterateWithProof(steps, fn),
+    dropProof,
+  ),
+)(seed)
+
+/**
+ * Apply a binary transformation function to a seed multiple times and return the result
+ * @since 0.22.0
+ * @example
+ * pipe(
+ *   LCG.mkSeed,
+ *   iterateBinary(10, LCG.shuffle, String.split("", "madlib"))
+ * )(100)
+ */
+export iterateBinary = (steps, fn, active, seed) => pipe(
+  iterateBinaryWithProof(steps, fn, active),
+  dropProof,
+)(seed)
+
+// CONVERTERS
+
+/**
+ * Generate a floating value from a seed
+ * @since 0.22.0
+ * @example
+ * LCG.toFloat(LCG.mkSeed(100))
+ */
+toFloat :: Seed -> Float
+export toFloat = pipe(
+  next,
+  unSeed,
+  (x) => (x / LCG_M),
+)
+
+/**
+ * Generate a random integer between two integer bounds, relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.toInt(0, 100, LCG.mkSeed(10))
+ */
+toInt :: Integer -> Integer -> Seed -> Integer
+export toInt = (low, high, seed) => pipe(
+  toFloat,
+  intGradient(low, high),
+)(seed)
+
+/**
+ * Generate a random boolean relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.toBool(LCG.mkSeed(10))
+ */
+toBool :: Seed -> Boolean
+export toBool = pipe(
+  toFloat,
+  (f) => f > 0.5,
+)
+
+/**
+ * Pick a value from a list relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.pick([0,1,2,3,4,5], LCG.mkSeed(10))
+ */
+seededPick :: List a -> Seed -> Maybe a
+export seededPick = (list, seed) => pipe(
+  List.nth(toInt(0, List.length(list) - 1, seed)),
+)(list)
+
+
+/**
+ * Swap the value of two indices in a list, relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.swap([0,1,2,3,4,5], LCG.mkSeed(10))
+ */
+swap :: List a -> Seed -> { current :: Seed, stack :: List a }
+swap = (list, prev) => {
+  bounded = toInt(0, List.length(list) - 1)
+  x = bounded(prev)
+  current = next(prev)
+  y = bounded(current)
+  fromStack = List.nth($, list)
+  nthX = fromStack(x)
+  nthY = fromStack(y)
+  return {
+    stack: pipe(
+      List.setMaybe(y, nthX),
+      List.setMaybe(x, nthY),
+    )(list),
+    current,
+  }
+}
+
+/**
+ * Walk an array, swapping two indices for each iteration, relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.swapWalk(["ka", "dabra", "abra"], LCG.mkSeed(10))
+ */
+swapWalk :: List a -> Seed -> { current :: Seed, stack :: List a }
+swapWalk = (list, seed) => pipe(
+  List.reduce((agg, _) => swap(agg.stack, agg.current), { stack: list, current: seed }),
+)(list)
+
+/**
+ * Shuffle an array multiple times, relative to a seed
+ * @since 0.22.0
+ * @example
+ * LCG.shuffle(["ka", "dabra", "abra"], LCG.mkSeed(10))
+ */
+seededShuffle :: List a -> Seed -> List a
+export seededShuffle = (list, seed) => pipe(
+  swapWalk(list),
+  (s) => swapWalk(s.stack, s.current),
+  (s) => swapWalk(s.stack, s.current),
+  (s) => swapWalk(s.stack, s.current),
+  (s) => swapWalk(s.stack, s.current),
+  .stack,
+)(seed)
+
+export alias Random = {
+  boolean :: {} -> Boolean,
+  float :: {} -> Float,
+  integer :: Integer -> Integer -> Integer,
+  pick :: List a -> Maybe a,
+  shuffle :: List a -> List a,
+}
+
+generate :: Integer -> Random
+export generate = (i) => {
+  seed = mkSeed(i)
+  // every function needs to call reseed or the resulting
+  // values won't change between calls!
+  reseed = () => {
+    seed = next(seed)
+  }
+  float = () => {
+    x = toFloat(seed)
+    reseed()
+    return x
+  }
+  integer = (low, high) => {
+    x = toInt(low, high, seed)
+    reseed()
+    return x
+  }
+  pick = (xs) => {
+    x = seededPick(xs, seed)
+    reseed()
+    return x
+  }
+  shuffle = (xs) => {
+    x = seededShuffle(xs, seed)
+    reseed()
+    return x
+  }
+  boolean = () => {
+    x = toBool(seed)
+    reseed()
+    return x
+  }
+  return { boolean, float, integer, pick, shuffle }
+}
+
+generateFromString :: String -> Random
+export generateFromString = (s) => {
+  seed = mkSeedFromString(s)
+  // every function needs to call reseed or the resulting
+  // values won't change between calls!
+  reseed = () => {
+    seed = next(seed)
+  }
+  float = () => {
+    x = toFloat(seed)
+    reseed()
+    return x
+  }
+  integer = (low, high) => {
+    x = toInt(low, high, seed)
+    reseed()
+    return x
+  }
+  pick = (xs) => {
+    x = seededPick(xs, seed)
+    reseed()
+    return x
+  }
+  shuffle = (xs) => {
+    x = seededShuffle(xs, seed)
+    reseed()
+    return x
+  }
+
+  boolean = () => {
+    x = toBool(seed)
+    reseed()
+    return x
+  }
+  return { boolean, float, integer, pick, shuffle }
+}

--- a/prelude/__internal__/Random.mad
+++ b/prelude/__internal__/Random.mad
@@ -4,10 +4,9 @@ import Byte from "Byte"
 import ByteArray from "ByteArray"
 import Float from "Float"
 import Integer from "Integer"
-import { floor, mod } from "Math"
+import List from "List"
+import { floor } from "Math"
 import Tuple from "Tuple"
-
-import List from "./List"
 
 
 

--- a/prelude/__internal__/Random.spec.mad
+++ b/prelude/__internal__/Random.spec.mad
@@ -1,0 +1,190 @@
+import Float from "Float"
+import Math from "Math"
+import { Just } from "Maybe"
+import String from "String"
+
+import {
+  LCG_A,
+  LCG_C,
+  LCG_M,
+  SEED_MAX,
+  SEED_MIN,
+  Seed,
+  apply,
+  generate,
+  generateFromString,
+  intGradient,
+  iterateBinary,
+  mkSeed,
+  mkSeedFromString,
+  modClamp,
+  next,
+  perturbation,
+  seededShuffle,
+  stepN,
+  unSeed,
+} from "./Random"
+import { assertEquals, test } from "./Test"
+
+
+
+ALPHABET = String.split("", "abcdefghjiklmnopqrtuvwxyz")
+// Tests are async so we don't wanna have a shared random generator here
+TEST_SEED = 1000
+
+naiveRandom = () => Float.toInteger(Math.floor(Math.random() * 10000))
+
+test("mkSeed will clamp values over the max", () => assertEquals(mkSeed(SEED_MAX + 1), Seed(2)))
+
+test(
+  "mkSeed will clamp values under the min",
+  () => assertEquals(mkSeed(SEED_MIN - 1), Seed(2147483646)),
+)
+test(
+  "unSeed",
+  () => {
+    x = 100
+    return assertEquals(x, unSeed(Seed(x)))
+  },
+)
+test("apply", () => assertEquals(Seed(100), apply((x) => x * 2, Seed(50))))
+test(
+  "step",
+  () => {
+    a = mkSeed(100)
+    b = next(a)
+    return assertEquals(unSeed(b), 4827100)
+  },
+)
+
+
+test(
+  "stepN",
+  () => pipe(
+    stepN(5),
+    assertEquals($, Seed(1708473988)),
+  )(mkSeed(100)),
+)
+
+
+test("perturbation", () => assertEquals(perturbation(LCG_C, LCG_A, 23, LCG_M), 23))
+test("perturbation zeroes", () => assertEquals(perturbation(0, 0, 0, 1), 0))
+test("perturbation ones", () => assertEquals(perturbation(1, 2, 3, 2), 1))
+
+threeClamped = modClamp($, $, 3)
+test("modClamp - under", () => assertEquals(threeClamped(7, 21), 24))
+test("modClamp - over", () => assertEquals(threeClamped(1, 1000), 3))
+
+test("intGradient", () => assertEquals(500, intGradient(0, 1000, 0.5)))
+
+test(
+  "iterateBinary",
+  () => {
+    seed = mkSeedFromString("iterateBinary")
+    shuffled = pipe(
+      iterateBinary(2, seededShuffle, ALPHABET),
+      map(String.join("")),
+    )(seed)
+    return assertEquals(
+      shuffled,
+      ["kmjbgzxorpvuqtadlfhynwcei", "vqpmxicafdrylhkbuzoetwjgn", "rlwqcnjkzbfeuovmydaghipxt"],
+    )
+  },
+)
+
+
+test(
+  "two random instances should have identical outputs in cycle - boolean",
+  () => do {
+    num = naiveRandom()
+    r1 = generate(num)
+    r2 = generate(num)
+    _ <- assertEquals(r1.boolean(), r2.boolean())
+    _ <- assertEquals(r1.boolean(), r2.boolean())
+    _ <- assertEquals(r1.boolean(), r2.boolean())
+    _ <- assertEquals(r1.boolean(), r2.boolean())
+    return assertEquals(r1.boolean(), r2.boolean())
+  },
+)
+
+test(
+  "two random instances should have identical outputs in cycle - integer",
+  () => do {
+    num = naiveRandom()
+    r1 = generate(num)
+    r2 = generate(num)
+    a = 1
+    z = 10000
+    _ <- assertEquals(r1.integer(a, z), r2.integer(a, z))
+    _ <- assertEquals(r1.integer(a, z), r2.integer(a, z))
+    _ <- assertEquals(r1.integer(a, z), r2.integer(a, z))
+    _ <- assertEquals(r1.integer(a, z), r2.integer(a, z))
+    return assertEquals(r1.integer(a, z), r2.integer(a, z))
+  },
+)
+
+
+test(
+  "two random instances should have identical outputs in cycle - float",
+  () => do {
+    num = naiveRandom()
+    r1 = generate(num)
+    r2 = generate(num)
+    _ <- assertEquals(r1.float(), r2.float())
+    _ <- assertEquals(r1.float(), r2.float())
+    _ <- assertEquals(r1.float(), r2.float())
+    _ <- assertEquals(r1.float(), r2.float())
+    return assertEquals(r1.float(), r2.float())
+  },
+)
+
+test(
+  "two random instances should have identical outputs in cycle - pick",
+  () => do {
+    num = naiveRandom()
+    r1 = generate(num)
+    r2 = generate(num)
+    _ <- assertEquals(r1.pick(ALPHABET), r2.pick(ALPHABET))
+    _ <- assertEquals(r1.pick(ALPHABET), r2.pick(ALPHABET))
+    _ <- assertEquals(r1.pick(ALPHABET), r2.pick(ALPHABET))
+    _ <- assertEquals(r1.pick(ALPHABET), r2.pick(ALPHABET))
+    return assertEquals(r1.pick(ALPHABET), r2.pick(ALPHABET))
+  },
+)
+
+test(
+  "two random instances should have identical outputs in cycle - shuffle",
+  () => do {
+    num = naiveRandom()
+    r1 = generate(num)
+    r2 = generate(num)
+    _ <- assertEquals(
+      pipe(
+        r1.shuffle,
+        String.join(""),
+      )(ALPHABET),
+      pipe(
+        r2.shuffle,
+        String.join(""),
+      )(ALPHABET),
+    )
+    return assertEquals(
+      pipe(
+        r1.shuffle,
+        String.join(""),
+      )(ALPHABET),
+      pipe(
+        r2.shuffle,
+        String.join(""),
+      )(ALPHABET),
+    )
+  },
+)
+
+test(
+  "generateFromString - works like `generate` but can take a string as a seed",
+  () => do {
+    r = generateFromString("cool")
+    return assertEquals(r.float(), 0.583066370609713)
+  },
+)

--- a/prelude/__internal__/Random.spec.mad
+++ b/prelude/__internal__/Random.spec.mad
@@ -1,7 +1,7 @@
 import Float from "Float"
 import Math from "Math"
-import { Just } from "Maybe"
 import String from "String"
+import { assertEquals, test } from "Test"
 
 import {
   LCG_A,
@@ -24,13 +24,10 @@ import {
   stepN,
   unSeed,
 } from "./Random"
-import { assertEquals, test } from "./Test"
 
 
 
 ALPHABET = String.split("", "abcdefghjiklmnopqrtuvwxyz")
-// Tests are async so we don't wanna have a shared random generator here
-TEST_SEED = 1000
 
 naiveRandom = () => Float.toInteger(Math.floor(Math.random() * 10000))
 

--- a/prelude/__internal__/Test.mad
+++ b/prelude/__internal__/Test.mad
@@ -8,11 +8,11 @@ import { Just, Nothing, fromMaybe } from "Maybe"
 import Monad from "Monad"
 import {} from "Number"
 import Process from "Process"
+import { pShow } from "Show"
 import String from "String"
 import Terminal from "Terminal"
 import Tuple from "Tuple"
 import Wish from "Wish"
-import { pShow } from "Show"
 
 
 
@@ -97,9 +97,9 @@ collector = makeResultCollector()
 
 // Test API
 
-export type AssertionError a
-  = AssertionError(a, a)
-  | Error(a)
+export type AssertionError
+  = AssertionError(String, String)
+  | Error(String)
   | ErrorWithMessage(String)
   | NotImplemented
 
@@ -161,32 +161,33 @@ mergeReports = (t1, t2) => TestReport(
 )
 
 
-assertEquals :: Eq a => a -> a -> Wish.Wish (AssertionError a) {}
+assertEquals :: (Show a, Eq a) => a -> a -> Wish.Wish AssertionError {}
 export assertEquals = (actual, expected) => actual == expected
   ? of({})
-  : Wish.bad(AssertionError(expected, actual))
+  : Wish.bad(AssertionError(pShow(expected), pShow(actual)))
 
 
 indent :: Integer -> String -> String
 indent = (amount, x) => pipe(
   String.lines,
-  map((line) => pipe(
-    spaces,
-    mappend($, line)
-  )(amount)),
-  String.unlines
+  map(
+    (line) => pipe(
+      spaces,
+      mappend($, line),
+    )(amount),
+  ),
+  String.unlines,
 )(x)
 
 
-renderValue :: Show a => (String -> String) -> a -> String
+renderValue :: (String -> String) -> String -> String
 renderValue = (colorize, value) => pipe(
-  pShow,
   indent(4),
   (s) => IS_COLOR_ENABLED ? colorize(s) : s,
 )(value)
 
 
-renderAssertionError :: Show a => String -> AssertionError a -> String
+renderAssertionError :: String -> AssertionError -> String
 renderAssertionError = (description, assertionError) => where(assertionError) {
   AssertionError(expected, actual) =>
     IO.red(`${CHAR_CROSS} ${description}`)
@@ -195,21 +196,15 @@ renderAssertionError = (description, assertionError) => where(assertionError) {
       ++ "\n  actual:\n"
       ++ renderValue(Terminal.text.brightRed, actual)
       ++ "\n"
-  
+
   ErrorWithMessage(message) =>
-    IS_COLOR_ENABLED
-      ? IO.red(`${CHAR_CROSS} ${message}\n`)
-      : `${CHAR_CROSS} ${message}\n`
-  
+    IS_COLOR_ENABLED ? IO.red(`${CHAR_CROSS} ${message}\n`) : `${CHAR_CROSS} ${message}\n`
+
   Error(err) =>
-    IS_COLOR_ENABLED
-      ? IO.red(`${CHAR_CROSS} ${show(err)}`)
-      : `${CHAR_CROSS} ${show(err)}`
-  
+    IS_COLOR_ENABLED ? IO.red(`${CHAR_CROSS} ${show(err)}`) : `${CHAR_CROSS} ${show(err)}`
+
   NotImplemented =>
-    IS_COLOR_ENABLED
-      ? IO.red(`${CHAR_CROSS} not implemented`)
-      : `${CHAR_CROSS} not implemented`
+    IS_COLOR_ENABLED ? IO.red(`${CHAR_CROSS} not implemented`) : `${CHAR_CROSS} not implemented`
 }
 
 
@@ -254,10 +249,17 @@ renderAssertionError = (description, assertionError) => where(assertionError) {
 // )(t)
 
 
-test :: Show a => String -> (String -> Wish.Wish (AssertionError a) {}) -> Wish.Wish TestResult TestResult
+
+test :: String -> (String -> Wish.Wish AssertionError {}) -> Wish.Wish TestResult TestResult
 export test = (description, testFunction) => pipe(
   testFunction,
-  bimap(pipe(renderAssertionError(description), Failure(description)), always(Success(description))),
+  bimap(
+    pipe(
+      renderAssertionError(description),
+      Failure(description),
+    ),
+    always(Success(description)),
+  ),
 )(description)
 
 
@@ -327,7 +329,9 @@ printSuiteResults = (results) => {
             preparedSuitePath = prepareSuitePath(true, suitePath)
             coloredCounts = if (IS_COLOR_ENABLED) {
               failed > 0 ? Terminal.text.brightRed(counts) : Terminal.text.brightGreen(counts)
-            } else { counts }
+            } else {
+              counts
+            }
             prefix = total == success + failed
               ? failed > 0 ? PREFIX_FAIL : PREFIX_PASS
               : PREFIX_RUNS
@@ -480,8 +484,11 @@ runTestSuite = (suitePath, beforeAll, afterAll, testsInSuite) => pipe(
 )(testsInSuite)
 
 
-runAllTestSuites :: (Show e, Show f) => List #[String, {} -> Wish e a, {} -> Wish f b, List (Wish TestResult TestResult)]
-  -> ({} -> {})
+
+runAllTestSuites :: (
+  Show e,
+  Show f
+) => List #[String, {} -> Wish e a, {} -> Wish f b, List (Wish TestResult TestResult)] -> {} -> {}
 export runAllTestSuites = (testSuites) => pipe(
   map(
     where {
@@ -490,7 +497,9 @@ export runAllTestSuites = (testSuites) => pipe(
     },
   ),
   (suites) => {
-    if (IS_COLOR_ENABLED) { printSuiteResults(collector.getResults()) }
+    if (IS_COLOR_ENABLED) {
+      printSuiteResults(collector.getResults())
+    }
     return suites
   },
   Wish.parallel,
@@ -498,14 +507,18 @@ export runAllTestSuites = (testSuites) => pipe(
   Wish.fulfill(
     () => ({}),
     (report) => {
-      if (!IS_COLOR_ENABLED) { printSuiteResults(collector.getResults()) }
+      if (!IS_COLOR_ENABLED) {
+        printSuiteResults(collector.getResults())
+      }
       IO.put(getMessage(report))
       IO.putLine(
         `Test suites: ${show(List.length(testSuites))}  tests: ${show(getTotal(report))}  passed: ${
           show(getSuccessCount(report))
         }  failed: ${show(getFailureCount(report))}`,
       )
-      if (getFailureCount(report) > 0) { Process.exit(1) }
+      if (getFailureCount(report) > 0) {
+        Process.exit(1)
+      }
     },
   ),
 )(testSuites)


### PR DESCRIPTION
#### Test.mad

- Changes to AssertionError to afford mixed results when asserting multiple times in a test

#### List.mad

- `set` - Set the value at a given index in the list
- `setMaybe` - Set the value at a given index in the list, maybe

#### Random.mad

A bunch of stuff here, but the core API is:
- `generate` - Create a PRNG instance from an integer seed
- `generateFromString` - Create a PRNG instance from a string seed