### PR TITLE
Unify random generator functions

### DIFF
--- a/prelude/__internal__/Random.mad
+++ b/prelude/__internal__/Random.mad
@@ -4,10 +4,9 @@ import Byte from "Byte"
 import ByteArray from "ByteArray"
 import Float from "Float"
 import Integer from "Integer"
+import List from "List"
 import { floor } from "Math"
 import Tuple from "Tuple"
-
-import List from "./List"
 
 
 

--- a/prelude/__internal__/Random.mad
+++ b/prelude/__internal__/Random.mad
@@ -4,9 +4,10 @@ import Byte from "Byte"
 import ByteArray from "ByteArray"
 import Float from "Float"
 import Integer from "Integer"
-import List from "List"
 import { floor } from "Math"
 import Tuple from "Tuple"
+
+import List from "./List"
 
 
 
@@ -405,13 +406,14 @@ export alias Random = {
   shuffle :: List a -> List a,
 }
 
-generate :: Integer -> Random
-export generate = (i) => {
-  seed = mkSeed(i)
+generateFromSeed :: Seed -> Random
+export generateFromSeed = (initialSeed) => {
+  seed = initialSeed
+  get = () => seed
   // every function needs to call reseed or the resulting
   // values won't change between calls!
   reseed = () => {
-    seed = next(seed)
+    seed = next(get())
   }
   float = () => {
     x = toFloat(seed)
@@ -440,40 +442,16 @@ export generate = (i) => {
   }
   return { boolean, float, integer, pick, shuffle }
 }
+
+
+generate :: Integer -> Random
+export generate = pipe(
+  mkSeed,
+  generateFromSeed,
+)
 
 generateFromString :: String -> Random
-export generateFromString = (s) => {
-  seed = mkSeedFromString(s)
-  // every function needs to call reseed or the resulting
-  // values won't change between calls!
-  reseed = () => {
-    seed = next(seed)
-  }
-  float = () => {
-    x = toFloat(seed)
-    reseed()
-    return x
-  }
-  integer = (low, high) => {
-    x = toInt(low, high, seed)
-    reseed()
-    return x
-  }
-  pick = (xs) => {
-    x = seededPick(xs, seed)
-    reseed()
-    return x
-  }
-  shuffle = (xs) => {
-    x = seededShuffle(xs, seed)
-    reseed()
-    return x
-  }
-
-  boolean = () => {
-    x = toBool(seed)
-    reseed()
-    return x
-  }
-  return { boolean, float, integer, pick, shuffle }
-}
+export generateFromString = pipe(
+  mkSeedFromString,
+  generateFromSeed,
+)


### PR DESCRIPTION
Minor change to make `generate` and `generateFromSeed` use the same underlying implementation rather than copypasta.