### PR TITLE
Rename `pushChar` to `prependChar`

### DIFF
--- a/prelude/__internal__/Char.mad
+++ b/prelude/__internal__/Char.mad
@@ -30,17 +30,26 @@ export fromShort = extern "madlib__number__shortToChar"
  * isDigit('3') // true
  */
 isDigit :: Char -> Boolean
-export isDigit = (s) =>
-  s == '0' ||
-  s == '1' ||
-  s == '2' ||
-  s == '3' ||
-  s == '4' ||
-  s == '5' ||
-  s == '6' ||
-  s == '7' ||
-  s == '8' ||
-  s == '9'
+export isDigit = (s) => s
+    == '0'
+    || s
+    == '1'
+    || s
+    == '2'
+    || s
+    == '3'
+    || s
+    == '4'
+    || s
+    == '5'
+    || s
+    == '6'
+    || s
+    == '7'
+    || s
+    == '8'
+    || s
+    == '9'
 
 
 /**
@@ -54,8 +63,8 @@ export isDigit = (s) =>
  */
 isLetter :: Char -> Boolean
 export isLetter = (c) => pipe(
-  String.pushChar($, ""),
-  String.match("[a-zA-Z]+")
+  String.prependChar($, ""),
+  String.match("[a-zA-Z]+"),
 )(c)
 
 

--- a/prelude/__internal__/FilePath.mad
+++ b/prelude/__internal__/FilePath.mad
@@ -1,8 +1,8 @@
-import String from "String"
 import {} from "Char"
-import { filter, first, last, drop, dropLast } from "List"
-import { fromMaybe, Nothing, Just } from "Maybe"
 import { complement, equals, identity, ifElse } from "Function"
+import { drop, dropLast, filter, first, last } from "List"
+import { Just, Nothing, fromMaybe } from "Maybe"
+import String from "String"
 
 
 
@@ -20,7 +20,7 @@ dropTrailingPathSeparator :: FilePath -> FilePath
 export dropTrailingPathSeparator = ifElse(
   (path) => path != "/" && String.lastChar(path) == Just('/'),
   String.dropLast(1),
-  identity
+  identity,
 )
 
 
@@ -33,8 +33,11 @@ performSplitPath = (buffer, foundSlash, path) => where(String.firstChar(path)) {
 
   Just(char) =>
     foundSlash
-      ? mappend([buffer], performSplitPath(String.pushChar(char, ""), false, String.drop(1, path)))
-      : performSplitPath(buffer ++ String.pushChar(char, ""), false, String.drop(1, path))
+      ? mappend(
+        [buffer],
+        performSplitPath(String.prependChar(char, ""), false, String.drop(1, path)),
+      )
+      : performSplitPath(buffer ++ String.prependChar(char, ""), false, String.drop(1, path))
 }
 
 
@@ -60,10 +63,21 @@ joinPath :: List FilePath -> FilePath
 export joinPath = pipe(
   filter(complement(String.isEmpty)),
   ifElse(
-    pipe(first, equals(Just("/"))),
-    pipe(drop(1), map(dropTrailingPathSeparator), String.join("/"), mappend("/")),
-    pipe(map(dropTrailingPathSeparator), String.join("/"))
-  )
+    pipe(
+      first,
+      equals(Just("/")),
+    ),
+    pipe(
+      drop(1),
+      map(dropTrailingPathSeparator),
+      String.join("/"),
+      mappend("/"),
+    ),
+    pipe(
+      map(dropTrailingPathSeparator),
+      String.join("/"),
+    ),
+  ),
 )
 
 
@@ -80,18 +94,24 @@ export canonicalizePath = pipe(
   map(
     pipe(
       ifElse(
-        pipe(String.take(2), equals("./")),
+        pipe(
+          String.take(2),
+          equals("./"),
+        ),
         String.drop(2),
-        identity
+        identity,
       ),
       ifElse(
-        pipe(String.lastChar, equals(Just('/'))),
+        pipe(
+          String.lastChar,
+          equals(Just('/')),
+        ),
         String.replace("([^/]+)/*", "$1/"),
-        identity
-      )
-    )
+        identity,
+      ),
+    ),
   ),
-  joinPath
+  joinPath,
 )
 
 
@@ -107,7 +127,7 @@ dropPathSegments :: Integer -> FilePath -> FilePath
 export dropPathSegments = (howMany) => pipe(
   splitPath,
   drop(howMany),
-  joinPath
+  joinPath,
 )
 
 
@@ -122,7 +142,7 @@ parentPath :: FilePath -> FilePath
 export parentPath = pipe(
   splitPath,
   dropLast(1),
-  joinPath
+  joinPath,
 )
 
 
@@ -143,9 +163,7 @@ export isRootPathOf = (root, path) => {
   pathStart = dropTrailingPathSeparator(fromMaybe("", first(pathParts)))
 
   return rootStart == pathStart || rootStart == ""
-    ? rootStart == ""
-      ? true
-      : isRootPathOf(dropPathSegments(1, root), dropPathSegments(1, path))
+    ? rootStart == "" ? true : isRootPathOf(dropPathSegments(1, root), dropPathSegments(1, path))
     : false
 }
 
@@ -164,13 +182,11 @@ export takeFileName = pipe(
   last,
   where {
     Just(part) =>
-      String.lastChar(part) == Just('/')
-        ? ""
-        : part
+      String.lastChar(part) == Just('/') ? "" : part
 
     Nothing =>
       ""
-  }
+  },
 )
 
 
@@ -188,5 +204,5 @@ export takeExtension = pipe(
   String.split("."),
   last,
   map(ifElse(String.isEmpty, identity, mappend("."))),
-  fromMaybe("")
+  fromMaybe(""),
 )

--- a/prelude/__internal__/Parse.mad
+++ b/prelude/__internal__/Parse.mad
@@ -510,7 +510,7 @@ string :: String -> Parser String
 export string = (s) => where(String.firstChar(s)) {
   Just(c) =>
     pipe(
-      map((a, b) => String.pushChar(a, b)),
+      map((a, b) => String.prependChar(a, b)),
       ap($, string(String.drop(1, s))),
     )(char(c))
 

--- a/prelude/__internal__/String.mad
+++ b/prelude/__internal__/String.mad
@@ -1,9 +1,14 @@
 import type { Maybe } from "Maybe"
+
 import List from "List"
+
+
 
 #iftarget js
 
 import { Just, Nothing } from "Maybe"
+
+
 
 #endif
 
@@ -114,7 +119,7 @@ export split = extern "madlib__string__split"
 join :: String -> List String -> String
 export join = (a, xs) => pipe(
   List.intersperse(a),
-  List.reduce(mappend, "")
+  List.reduce(mappend, ""),
 )(xs)
 
 /**
@@ -235,7 +240,7 @@ filterChars :: (Char -> Boolean) -> String -> String
 export filterChars = (predicate, s) => pipe(
   toList,
   List.filter(predicate),
-  fromList
+  fromList,
 )(s)
 
 /**
@@ -245,7 +250,7 @@ export filterChars = (predicate, s) => pipe(
 reduceChars :: (a -> Char -> a) -> a -> String -> a
 export reduceChars = (f, initial, s) => pipe(
   toList,
-  List.reduce(f, initial)
+  List.reduce(f, initial),
 )(s)
 
 
@@ -298,7 +303,7 @@ dropWhile :: (Char -> Boolean) -> String -> String
 export dropWhile = (predicate, s) => pipe(
   toList,
   List.dropWhile(predicate),
-  fromList
+  fromList,
 )(s)
 
 /**
@@ -323,7 +328,7 @@ takeWhile :: (Char -> Boolean) -> String -> String
 export takeWhile = (predicate, s) => pipe(
   toList,
   List.takeWhile(predicate),
-  fromList
+  fromList,
 )(s)
 
 
@@ -439,7 +444,7 @@ export length = extern "madlib__string__length"
 repeat :: Char -> Integer -> String
 export repeat = (c, n) => pipe(
   List.repeat(c),
-  fromList
+  fromList,
 )(n)
 
 
@@ -457,9 +462,11 @@ export match = (regex, input) => #- input.match(regex) !== null -#
  * @since 0.18.7
  */
 replace :: String -> String -> String -> String
-export replace = (regex, replacing, input) => (#-
+export replace = (regex, replacing, input) => (
+  #-
   input.replace(new RegExp(regex, "g"), replacing)
--#)
+-#
+)
 
 #elseif llvm
 
@@ -486,8 +493,8 @@ export replace = extern "madlib__string__replace"
  * Pushes a char at the beginning of a String
  * @since 0.12.0
  */
-pushChar :: Char -> String -> String
-export pushChar = (c, s) => #- { return c + s } -#
+prependChar :: Char -> String -> String
+export prependChar = (c, s) => #- { return c + s } -#
 
 /**
  * Appends a char at the end of a String
@@ -502,8 +509,8 @@ export appendChar = (c, s) => #- { return s + c } -#
  * pushes a char at the beginning of a String
  * @since 0.12.0
  */
-pushChar :: Char -> String -> String
-export pushChar = extern "madlib__string__pushChar"
+prependChar :: Char -> String -> String
+export prependChar = extern "madlib__string__prependChar"
 
 /**
  * appends a char at the end of a String
@@ -526,7 +533,7 @@ reverse :: String -> String
 export reverse = (s) => pipe(
   toList,
   List.reverse,
-  fromList
+  fromList,
 )(s)
 
 
@@ -540,7 +547,7 @@ export reverse = (s) => pipe(
 includes :: Char -> String -> Boolean
 export includes = (c, s) => pipe(
   toList,
-  List.includes(c)
+  List.includes(c),
 )(s)
 
 
@@ -555,7 +562,7 @@ export includes = (c, s) => pipe(
 startsWith :: String -> String -> Boolean
 export startsWith = (subset, s) => pipe(
   toList,
-  List.startsWith(toList(subset))
+  List.startsWith(toList(subset)),
 )(s)
 
 
@@ -570,7 +577,7 @@ export startsWith = (subset, s) => pipe(
 contains :: String -> String -> Boolean
 export contains = (subset, s) => pipe(
   toList,
-  List.contains(toList(subset))
+  List.contains(toList(subset)),
 )(s)
 
 
@@ -585,5 +592,5 @@ export contains = (subset, s) => pipe(
 endsWith :: String -> String -> Boolean
 export endsWith = (subset, s) => pipe(
   toList,
-  List.endsWith(toList(subset))
+  List.endsWith(toList(subset)),
 )(s)

--- a/prelude/__internal__/String.spec.mad
+++ b/prelude/__internal__/String.spec.mad
@@ -1,9 +1,10 @@
 import {} from "Char"
-import { EQ, LT, GT, eq } from "Compare"
+import { EQ, GT, LT, eq } from "Compare"
 import { Just } from "Maybe"
 import { assertEquals, test } from "Test"
 
 import String from "./String"
+
 
 
 test("compare String - GT", () => assertEquals(compare("John", "James"), GT))
@@ -126,7 +127,7 @@ test("repeat", () => assertEquals(String.repeat('a', 10), "aaaaaaaaaa"))
 test("toUpper", () => assertEquals(String.toUpper("atwzö2êéè‡‹©Ïƒ¬"), "ATWZÖ2ÊÉÈ‡‹©ÏƑ¬"))
 test("toLower", () => assertEquals(String.toLower("ATWZÖ2ÊÉÈ‡‹©ÏƑ¬"), "atwzö2êéè‡‹©ïƒ¬"))
 
-test("pushChar", () => assertEquals(String.pushChar('a', "bc"), "abc"))
+test("prependChar", () => assertEquals(String.prependChar('a', "bc"), "abc"))
 test("appendChar", () => assertEquals(String.appendChar('c', "ab"), "abc"))
 
 test("reverse", () => assertEquals(String.reverse("abc"), "cba"))

--- a/runtime/src/string.cpp
+++ b/runtime/src/string.cpp
@@ -323,7 +323,7 @@ char *madlib__string__slice(int64_t start, int64_t end, unsigned char *s) {
   return result;
 }
 
-char *madlib__string__pushChar(int32_t c, char* s) {
+char *madlib__string__prependChar(int32_t c, char* s) {
   char *encoded = utf8EncodeChar(c);
   size_t encodedLength = strlen(encoded);
   size_t stringLength = strlen(s);

--- a/runtime/src/string.hpp
+++ b/runtime/src/string.hpp
@@ -23,7 +23,7 @@ int64_t madlib__string__length(unsigned char *s);
 
 char *madlib__string__slice(int64_t start, int64_t end, unsigned char *s);
 
-char *madlib__string__pushChar(int32_t c, char* s);
+char *madlib__string__prependChar(int32_t c, char* s);
 char *madlib__string__appendChar(int32_t c, char* s);
 
 char *madlib__string__trim(char *s);


### PR DESCRIPTION
- `pushChar` connotes the wrong info, IMO (I'd sorta expect it to append rather than prepend, and possibly mutate / return the new length)
- `prependChar` makes more sense (and is a complement to the extant `appendChar`)
- This PR simply renames things, but if we want to make `pushChar` an alias, happy to amend this