### PR TITLE
feat: add padStart and padEnd to String

### DIFF
--- a/prelude/__internal__/String.mad
+++ b/prelude/__internal__/String.mad
@@ -447,6 +447,42 @@ export repeat = (c, n) => pipe(
   fromList,
 )(n)
 
+/**
+ * Pad the beginning of a string with a character up to a specific limit
+ * @since 0.23.8
+ * @example
+ * padStart('-', 3, ">") // "-->"
+ * padStart('-', 3, "cool") // "cool"
+ */
+padStart :: Char -> Integer -> String -> String
+export padStart = (pre, count, str) => {
+  len = length(str)
+  return if (len > count) {
+    str
+  } else do {
+    prefix = repeat(pre, count - len)
+    return prefix ++ str
+  }
+}
+
+/**
+ * Pad the end of a string with a character up to a specific limit
+ * @since 0.23.8
+ * @example
+ * padEnd('-', 3, "<") // "<--"
+ * padEnd('-', 3, "cool") // "cool"
+ */
+padEnd :: Char -> Integer -> String -> String
+export padEnd = (post, count, str) => {
+  len = length(str)
+  return if (len > count) {
+    str
+  } else do {
+    suffix = repeat(post, count - len)
+    return str ++ suffix
+  }
+}
+
 
 #iftarget js
 

--- a/prelude/__internal__/String.spec.mad
+++ b/prelude/__internal__/String.spec.mad
@@ -153,3 +153,19 @@ test("contains - false", () => assertEquals(String.contains("aü", "abüc"), fal
 test("endsWith - true", () => assertEquals(String.endsWith("c", "abüc"), true))
 test("endsWith - utf8", () => assertEquals(String.endsWith("üc", "abüc"), true))
 test("endsWith - false", () => assertEquals(String.endsWith("bü", "abüc"), false))
+
+test(
+  "padStart",
+  () => do {
+    _ <- assertEquals(String.padStart('-', 3, ">"), "-->")
+    return assertEquals(String.padStart('-', 3, "cool"), "cool")
+  },
+)
+
+test(
+  "padEnd",
+  () => do {
+    _ <- assertEquals(String.padEnd('-', 3, "<"), "<--")
+    return assertEquals(String.padEnd('-', 3, "cool"), "cool")
+  },
+)


### PR DESCRIPTION
Add `padStart` and `padEnd` to String, which allow for inserting repeated characters for the beginning or end of a string, respectively