### PR TITLE
IOError escape hatch

### DIFF
--- a/prelude/__internal__/IO.mad
+++ b/prelude/__internal__/IO.mad
@@ -13,6 +13,7 @@ import Error from "__IOError__"
 import {
   AddressAlreadyInUse,
   ArgumentListToLong,
+  GeneralError,
   PermissionDenied,
   UnknownError,
 } from "__IOError__"
@@ -24,6 +25,7 @@ export AddressAlreadyInUse
 export ArgumentListToLong
 export PermissionDenied
 export UnknownError
+export GeneralError
 
 prettyCase :: (String -> String) -> String -> String
 prettyCase = (color, str) => pipe(

--- a/prelude/__internal__/__IOError__.mad
+++ b/prelude/__internal__/__IOError__.mad
@@ -3,6 +3,7 @@ export type Error
   | ArgumentListToLong
   | PermissionDenied
   | UnknownError
+  | GeneralError(String)
 
 fromLibuvError :: Integer -> Error
 export fromLibuvError = where {


### PR DESCRIPTION
Since we don't have a comprehensive set of IO errors (nor, I think, do we want them currently) I thought it would be useful to be able to surface general errors with a specific string