### PR TITLE
add importAliases to `madlib new` behavior

### DIFF
--- a/compiler/main/Run/GeneratePackage.hs
+++ b/compiler/main/Run/GeneratePackage.hs
@@ -55,7 +55,12 @@ buildPackage path name version = do
 
 makeMadlibDotJson :: String -> String -> String
 makeMadlibDotJson name version = unlines
-  ["{", "  \"name\": \"" <> name <> "\",", "  \"version\": \"" <> version <> "\",", "  \"main\": \"src/Main.mad\"", "}"]
+  [ "{"
+  , "  \"name\": \"" <> name <> "\","
+  , "  \"version\": \"" <> version <> "\","
+  , "  \"main\": \"src/Main.mad\""
+  , "  \"importAliases\": { \".\": \"src\" }"
+  , "}"]
 
 mainDotMadContent :: String
 mainDotMadContent = unlines


### PR DESCRIPTION
I regularly end up manually adding:

```
  "importAliases": {
    ".": "src"
  }
```

to `madlib.json`, so I thought automatically adding it would save me some time (and honestly, I don't know why someone _wouldn't_ want it added by default)